### PR TITLE
Send back signal to web-tv frontend, for back key + ui hidden

### DIFF
--- a/src/ts/spatialnavigation/rootnavigationgroup.ts
+++ b/src/ts/spatialnavigation/rootnavigationgroup.ts
@@ -15,8 +15,15 @@ export class RootNavigationGroup extends NavigationGroup {
 
   public handleAction(action: Action) {
     if (!this.container.isUiShown) {
-      this.container.showUi();
-      this.focusFirstElement();
+      if (action === Action.BACK) {
+        // web-tv: send back signal to frontend code
+        // @ts-ignore
+        window.bitmovin?.customMessageHandler?.sendSynchronous?.("back");
+        return
+      } else {
+        this.container.showUi();
+        this.focusFirstElement();
+      }
     } else {
       this.container.showUi();
       super.handleAction(action);

--- a/src/ts/spatialnavigation/rootnavigationgroup.ts
+++ b/src/ts/spatialnavigation/rootnavigationgroup.ts
@@ -20,10 +20,11 @@ export class RootNavigationGroup extends NavigationGroup {
         // @ts-ignore
         window.bitmovin?.customMessageHandler?.sendSynchronous?.("back");
         return
-      } else {
-        this.container.showUi();
-        this.focusFirstElement();
       }
+
+      this.container.showUi();
+      this.focusFirstElement();
+
     } else {
       this.container.showUi();
       super.handleAction(action);


### PR DESCRIPTION
Virker (men hacket)

Har ikke fået tjekket om det ødelægger noget for expo-tv endnu

Den primære forskel på web-tv ifht til expo tv, er at bitmovin player i web-tv sluger "back"-knappen, så man ikke får "back" key event i web-tv-koden, når player ui er aktivt.